### PR TITLE
Build script environment cleanup

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -24,23 +24,23 @@ $iconvLib = Join-Path (pwd) libiconv_static$x64Dir\Release
 $iconvInc = Join-Path (pwd) ..\source\include
 # Make sure that libiconv.(lib|exp) is included
 Copy-Item -Force (Join-Path (pwd) .\$x64Dir\Release\*) -Destination $iconvLib
-cd ..\..
+cd -
 
 cd .\libxml2\win32
 cscript configure.js lib="$iconvLib" include="$iconvInc" vcmanifest=yes
 nmake
 $xmlLib = Join-Path (pwd) bin.msvc
 $xmlInc = Join-Path (pwd) ..\include
-cd ..\..
+cd -
 
 cd .\libxslt\win32
 cscript configure.js lib="$iconvLib;$xmlLib" include="$iconvInc;$xmlInc" vcmanifest=yes
 nmake
-cd ..\..
+cd -
 
 cd .\zlib
 nmake -f win32/Makefile.msc
-cd ..
+cd -
 
 # Pushed by Import-VisualStudioVars
 Pop-EnvironmentBlock

--- a/build.ps1
+++ b/build.ps1
@@ -42,6 +42,9 @@ cd .\zlib
 nmake -f win32/Makefile.msc
 cd ..
 
+# Pushed by Import-VisualStudioVars
+Pop-EnvironmentBlock
+
 # Bundle releases
 Function BundleRelease($name, $lib, $inc)
 {

--- a/clean.ps1
+++ b/clean.ps1
@@ -10,7 +10,7 @@ ForEach ($repo in "libiconv","libxslt","libxml2","zlib") {
     cd $repo
     Get-ChildItem -Exclude .git . | Remove-Item -Recurse
     git reset --hard
-    cd ..
+    cd -
 }
 
 if (Test-Path .\dist) { Remove-Item .\dist -Recurse }


### PR DESCRIPTION
While iterating on the build.ps1 script, I noticed that it started locking up or building the wrong things (confusing architecture state) after a few runs.

Two issues I identified:
* After running, the Visual Studio environment variables were never popped
* The 'cd' stack (from Pscx's `Set-LocationEx` alias) grows unboundedly