### PR TITLE
Remove 'dist\' from the filenames of AppVeyor artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,5 +14,5 @@ build_script:
        .\build.ps1
     }
 test: off
-artifacts:
-- path: dist/*
+test_script:
+- ps: Get-ChildItem dist\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
Code taken from .appveyor.yml in lxml