### PR TITLE
Add Visual Studio 2008 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,35 @@
 environment:
   matrix:
   - Architecture: x86
+    Compiler: vs2015
   - Architecture: x64
+    Compiler: vs2015
+  - Architecture: x86
+    Compiler: vs2008
+  - Architecture: x64
+    Compiler: vs2008
+    PYTHON_ARCH: 64
+    PATCH_VS2008: True
 install:
 - cmd: git submodule update --init --recursive
 - ps: install-module pscx -scope CurrentUser
+- ps: >-
+    if ($env:PATCH_VS2008 -eq 'True') {
+        # http://scikit-ci-addons.readthedocs.io/en/latest/addons.html#patch-vs2008-py
+        C:\Python27\python -m pip install scikit-ci-addons
+        C:\Python27\python -m ci_addons appveyor/patch_vs2008
+        # http://help.appveyor.com/discussions/kb/38-visual-studio-2008-64-bit-builds
+        Copy-Item "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat"
+    }
 build: off
 build_script:
 - ps: >-
-    if ($env:Architecture -eq 'x64') {
-       .\build.ps1 -x64
-    } else {
-       .\build.ps1
-    }
+    $x64param = if ($env:Architecture -eq 'x64') { $true } else { $false }
+
+    $vs2008param = if ($env:Compiler -eq 'vs2008') { $true } else { $false }
+
+    .\build.ps1 -x64:$x64param -vs2008:$vs2008param
+
 test: off
 test_script:
 - ps: Get-ChildItem dist\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
This will allow outputting builds of the libraries for building lxml for Python 2.6 or Python 2.7. The VS2008 builds have "vs2008." added before the platform tag to distinguish them.

As discussed in lxml/lxml#225, I hope this change is not too intrusive to take, even if you're not keen on releasing/maintaining the library builds yourself.

The worst part of it, in my opinion, is the patching needed for VS2008 x64 to work. I've logged scikit-build/scikit-ci-addons#35 to get the Copy-Item line built in to the scikit-ci-addons script.

The only other non-trivial part is that msbuild cannot build VS2008 solution files, and vcbuild will always build Win32 unless explicitly told otherwise.