### PR TITLE
appveyor: add vs2017 compiler to the build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 environment:
   matrix:
   - Architecture: x86
+    Compiler: vs2017
+  - Architecture: x64
+    Compiler: vs2017
+  - Architecture: x86
     Compiler: vs2015
   - Architecture: x64
     Compiler: vs2015


### PR DESCRIPTION
this is an attempt to fix #15 